### PR TITLE
0.1.1 - More Reliable Div Replacement

### DIFF
--- a/jobTabs.js
+++ b/jobTabs.js
@@ -29,9 +29,7 @@ const addJobLinks = () => {
                 for (const job of jobElements) {
                     const jobID = angular.element(job).scope().$ctrl.job.job_id;
                     const jobURL = "https://northeastern-csm.symplicity.com/students/app/jobs/detail/" + jobID;
-                    const orgHTML = job.outerHTML.substring(4, job.outerHTML.length - 6);
-                    const newHTML = "<a id='nutabs' href=" + '"' + jobURL + '"' + orgHTML + "</a>";
-                    job.outerHTML = newHTML;
+                    job.outerHTML = job.outerHTML.replace(/^<div/, "<a id='nutabs' href='" + jobURL + "'").replace(new RegExp("</div>$"), "</a>");
                 }
             }
         })();`;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "NUTabs",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Adds ability to open job postings from NUworks in a new tab.",
     "icons": {
         "512": "icons/new-tab.png"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nutabs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutabs",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Bowser extension which adds ability to open job postings from NUworks in a new tab",
     "main": "jobTabs.js",
     "scripts": {

--- a/updates.json
+++ b/updates.json
@@ -5,6 +5,10 @@
                 {
                     "version": "0.1.0",
                     "update_link": "https://github.com/VishalRamesh50/NUTabs/releases/download/0.1.0/nutabs-0.1.0-an+fx.xpi"
+                },
+                {
+                    "version": "0.1.1",
+                    "update_link": "https://github.com/VishalRamesh50/NUTabs/releases/download/0.1.1/nutabs-0.1.1-an+fx.xpi"
                 }
             ]
         }


### PR DESCRIPTION
## Problem
- Script incorrectly assumes that when changing job titles to an `anchor` tag, it was a `div` to start.
- If the script is run twice on the same page (which sometimes happens when two API requests are made), it will try to modify an already changed `anchor` tag while still using the hardcoded indices assuming it is a `div`.
- This causes the resulting element to have some excess information which happens to be ignored and seems not cause any issues but really should just be fixed.

## Solution
- Use regex string replacement to only change the HTML of the element by
     - Replacing the `div` with the `anchor` tag and the `href` at the start _only if_ the HTML starts with `<div`.
     - Replacing the closing div tag `</div>` with `</a>` _only if_ the HTML ends with `</div>`.