### PR TITLE
Allow for the job to automatically open in new tab

### DIFF
--- a/jobTabs.js
+++ b/jobTabs.js
@@ -25,11 +25,16 @@ const addJobLinks = () => {
             if ((jobElements.length === 0 || loadingBar) && !noJobResults) {
                 setTimeout(getJobElements, 1000);
             } else {
-                /* Replace all job title with an anchor tags and add the job URLs to it */
+                /* Replace all job title with an anchor tags and add the job URLs to it.
+                 Remove the click action on all the parents so the current page does not load the job.
+                 */
                 for (const job of jobElements) {
                     const jobID = angular.element(job).scope().$ctrl.job.job_id;
                     const jobURL = "https://northeastern-csm.symplicity.com/students/app/jobs/detail/" + jobID;
-                    job.outerHTML = job.outerHTML.replace(/^<div/, "<a id='nutabs' href='" + jobURL + "'").replace(new RegExp("</div>$"), "</a>");
+                    // Since the HTML is being changed the parent needs to be changed after the child but is not accessible after the change
+                    const parent = job.parentElement;
+                    job.outerHTML = job.outerHTML.replace(/^<div/, "<a id='nutabs' target='_blank' href='" + jobURL + "'").replace(new RegExp("</div>$"), "</a>");
+                    parent.outerHTML = parent.outerHTML.replace('ng-click="$ctrl.redirectToJob($ctrl.job.job_id)"', "");
                 }
             }
         })();`;


### PR DESCRIPTION
The motivation for this change is to allow for jobs to automatically
open in a new tab rather than having to directly right click and click
on "Open in a new tab". It is a more natural behavior to simply click
on each job element. Ctrl-click will also work by opening the tab but
keeping the current tab open.

By adding a target='_blank' the new link will open in a new tab.
However, when you simply click on it the parent div tag will still
receive the click and will redirect the current page. This behavior
can be removed by removing the click action from the parent element.
There is a little trick since the HTML is being changed the job body
will be inaccessible after the parent html is changed and vice versa.
So simply save the parent element and then change it afterwards.

Tested on Chrome and Firefox.